### PR TITLE
[Query] 회원 삭제

### DIFF
--- a/src/main/java/org/zerock/mreview/repository/ReviewRepository.java
+++ b/src/main/java/org/zerock/mreview/repository/ReviewRepository.java
@@ -2,6 +2,9 @@ package org.zerock.mreview.repository;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.zerock.mreview.entity.Member;
 import org.zerock.mreview.entity.Movie;
 import org.zerock.mreview.entity.Review;
 
@@ -10,4 +13,8 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @EntityGraph(attributePaths = {"member"}, type = EntityGraph.EntityGraphType.FETCH)
     List<Review> findByMovie(Movie movie);
+
+    @Modifying
+    @Query("DELETE FROM Review mr WHERE mr.member = :member")
+    void deleteByMember(Member member);
 }

--- a/src/test/java/org/zerock/mreview/repository/MemberRepositoryTests.java
+++ b/src/test/java/org/zerock/mreview/repository/MemberRepositoryTests.java
@@ -3,14 +3,19 @@ package org.zerock.mreview.repository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
 import org.zerock.mreview.entity.Member;
 
+import javax.transaction.Transactional;
 import java.util.stream.IntStream;
 
 @SpringBootTest
 public class MemberRepositoryTests {
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Test
     public void insertMembers() {
@@ -21,5 +26,17 @@ public class MemberRepositoryTests {
                     .nickname("reviewer" + i).build();
             memberRepository.save(member);
         });
+    }
+
+    @Commit
+    @Transactional
+    @Test
+    public void testDeleteMember() {
+        Long mid = 2L;
+
+        Member member = Member.builder().mid(mid).build();
+
+        reviewRepository.deleteByMember(member);
+        memberRepository.deleteById(mid);
     }
 }


### PR DESCRIPTION
- [x] 쿼리 작성
    - findByMember 함수의 쿼리 결과를 확인하니 비효율이라 @Query를 통해 직접 작성
    - [x] 트랜젝션 처리 (회원 삭제 시 작성한 리뷰 모두 삭제)
        - 리뷰를 먼저 삭제 후 회원을 삭제
- [x] 테스트

- resolved: #8